### PR TITLE
fix: task 부분 api 변경, 작업 생성과 체크박스 오류 수정

### DIFF
--- a/tasks/urls.py
+++ b/tasks/urls.py
@@ -2,16 +2,17 @@
 # MGP: 작업 관리 URL 패턴 수정
 # 백엔드 부분 대신 수정: RESTful API 구조로 변경, task_id 파라미터 추가
 from django.urls import path
-from .views import TaskCreateView, TaskDetailView, TaskDeleteView, TaskUpdateView, tasks_page
+from .views import TaskCreateView, TaskDetailView, TaskDeleteView, TaskListAPIView, TaskUpdateView, tasks_page
 
 urlpatterns = [
+    path('list/', TaskListAPIView, name='task-list'),
+    # API
+    path('create/', TaskCreateView.as_view(), name='task-create'),
+    path('<int:task_id>/', TaskDetailView.as_view(), name='task-detail'),
+    path('<int:task_id>/delete/', TaskDeleteView.as_view(), name='task-delete'),
+    path('<int:task_id>/update/', TaskUpdateView.as_view(), name='task-update'),
+
     # 프론트 페이지
     path('', tasks_page, name='tasks-page'),
-
-    # API
-    path('api/create/', TaskCreateView.as_view(), name='task-create'),
-    path('api/<int:task_id>/', TaskDetailView.as_view(), name='task-detail'),
-    path('api/<int:task_id>/delete/', TaskDeleteView.as_view(), name='task-delete'),
-    path('api/<int:task_id>/update/', TaskUpdateView.as_view(), name='task-update'),
 ]
 # ========================================

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -4,6 +4,8 @@ from teams.models import Team
 from .models import Task
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
+from rest_framework.decorators import api_view, permission_classes
+
 
 # ========================================
 # MGP: 작업 관리 페이지 뷰 수정
@@ -45,6 +47,20 @@ from django.shortcuts import get_object_or_404
 from .models import Task
 from teams.models import Team
 from .serializers import TaskSerializer
+
+#팀별 작업 리스트 반환하는 API 추가
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def TaskListAPIView(request, team_id):
+    team = get_object_or_404(Team, id=team_id)
+
+    team_tasks = Task.objects.filter(team=team, type='team')
+    personal_tasks = Task.objects.filter(team=team, type='personal', assignee=request.user)
+
+    return Response({
+        "team_tasks": TaskSerializer(team_tasks, many=True).data,
+        "personal_tasks": TaskSerializer(personal_tasks, many=True).data
+    })
 
 # 작업 생성
 class TaskCreateView(generics.CreateAPIView):

--- a/teamflow/urls.py
+++ b/teamflow/urls.py
@@ -37,7 +37,7 @@ urlpatterns = [
     # ========================================
     # MGP: 작업 관리 URL 패턴 추가
     # 백엔드 부분 대신 수정: tasks 앱 URL 연결
-    path('teams/<int:team_id>/tasks/', include('tasks.urls')),
+    path('api/dashboard/<int:team_id>/tasks/', include('tasks.urls')),
     # ========================================
 
     # 로그인 후 리다이렉트

--- a/templates/main/tasks.html
+++ b/templates/main/tasks.html
@@ -34,7 +34,7 @@
                 {% for task in team_tasks %}
                 <div class="task-item" data-task-id="{{ task.id }}">
                     <div class="task-checkbox {% if task.status == 'completed' %}checked{% endif %}" 
-                         onclick="toggleTaskStatus({{ task.id }}, '{{ task.status }}')"></div>
+                         data-task-id="{{ task.id }}"></div>
                     <div class="task-content">
                         <div class="task-header">
                             <span class="task-name {% if task.status == 'completed' %}completed{% endif %}">{{ task.name }}</span>
@@ -85,7 +85,7 @@
                 {% for task in personal_tasks %}
                 <div class="task-item" data-task-id="{{ task.id }}">
                     <div class="task-checkbox {% if task.status == 'completed' %}checked{% endif %}" 
-                         onclick="toggleTaskStatus({{ task.id }}, '{{ task.status }}')"></div>
+                         data-task-id="{{ task.id }}"></div>
                     <div class="task-content">
                         <div class="task-header">
                             <span class="task-name {% if task.status == 'completed' %}completed{% endif %}">{{ task.name }}</span>


### PR DESCRIPTION
## 수정 사항
### 1. Task 관련 API 수정
- 전체적인 api를 /api/dashboard/{team_id}/tasks/ 구조로 변경
- /api/dashboard/{team_id}/tasks/ 호출 시 JSON이 아닌 HTML 반환 → JSON 파싱 에러 발생
- TaskListAPIView 추가해 팀별 작업 목록 JSON 반환
- URL에 list/ suffix 추가해 HTML 뷰와 충돌 방지 (/api/dashboard/{team_id}/tasks/list/)
- 프론트에서 fetch URL도 list/로 변경

### 2. 작업 생성 오류 수정
- 작업 생성 시 API와 프론트 혼용으로 CSRF/데이터 누락 에러 발생, 개인 작업 담당자 설정 문제도 있었음
- 개인 작업 생성 시 자동으로 현재 로그인 사용자 할당
-  TaskCreateView에서 team_id를 URL 파라미터로 받아 팀 연결
- 생성 후 location.reload()로 목록 갱신 (필요 시 추후 AJAX 전환 가능)

### 3. 체크박스 오류 수정
- 인라인 onclick과 JS 이벤트 위임이 충돌해 체크박스 토글 안 됨
- UI만 토글되고 서버 반영 안 되거나 반대로 서버 반영만 되고 UI 갱신 안 됨
- 성공 알림 문구도 표시 안 됨
-> 인라인 onclick 제거하고 data-task-id로 이벤트 위임 통일
-> PATCH 성공 시 loadTasks()로 서버 최신 데이터 불러와 목록 갱신
->  실패 시만 알림 표시(성공 알림은 UX 위해 제거)

## 추가 수정 필요 사항
- 팀 전환시 team id에 따라 api 수정
- 반영은 되는데 오류 문구 뜨는거 수정 필요
