### PR TITLE
feat: AI 역할 추천 기능 구현

### DIFF
--- a/roles/clova_ai.py
+++ b/roles/clova_ai.py
@@ -1,46 +1,92 @@
 # ========================================
 # MGP: Clova AI API 설정 수정
 # 사용자 제공 API 키 적용 및 환경변수 의존성 제거
-import requests
 import os
+import openai # OpenAI SDK 임포트
 from pathlib import Path
 from dotenv import load_dotenv
+import json # JSON 파싱을 위해 추가
+from typing import Union, Tuple
 
-# ✅ 프로젝트 루트 경로 기준으로 .env 강제 로딩
+# 프로젝트 루트 경로 기준으로 .env 파일 강제 로딩
+# .env 파일에 OPENAI_API_KEY가 설정되어 있어야 합니다.
 BASE_DIR = Path(__file__).resolve().parent.parent
-load_dotenv(dotenv_path=BASE_DIR / ".env")  # 여기가 핵심!!!
+load_dotenv(dotenv_path=BASE_DIR / ".env")
 
-CLOVA_API_URL = "https://clovastudio.stream.naver.com/testapp/v1/chat-completions/HCX"
-# 사용자 제공 API 키 사용
-CLOVA_API_KEY = "nv-61fd3b43f97747159bd6eef23e4bead4MTQw"
+# ✅ 환경 변수에서 OPENAI_API_KEY 불러오기
+# 보안을 위해 API 키를 코드에 직접 노출하지 마세요.
+# OpenAI SDK는 기본적으로 OPENAI_API_KEY 환경 변수를 찾습니다.
+CLOVA_API_KEY = os.getenv("OPENAI_API_KEY") # <-- 변수 이름을 OPENAI_API_KEY로 변경
 
-# ✅ 확인 로그 찍기
-print("✅ CLOVA_API_KEY:", CLOVA_API_KEY)
-print("✅ NCP_API_URL:", os.getenv("NCP_API_URL"))
+# ✅ OpenAI 클라이언트 인스턴스화
+# Clova Studio의 OpenAI 호환 API 엔드포인트를 base_url로 설정합니다.
+# 이 URL은 앱 이름을 포함하지 않습니다. (SDK가 자동으로 처리)
+client = openai.OpenAI(
+    api_key=CLOVA_API_KEY,
+    base_url="https://clovastudio.stream.ntruss.com/v1/openai"
+)
 
-def call_clova_recommendation(prompt):
-    headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {CLOVA_API_KEY}",
-        "X-NCP-CLOVASTUDIO-MODEL": "GPT-4"
-    }
 
-    payload = {
-        "messages": [
-            {"role": "system", "content": "너는 팀 프로젝트 역할 추천 AI야."},
-            {"role": "user", "content": prompt}
+def call_clova_recommendation(prompt: str, role_types: list[str]) -> Union[Tuple[str, str], None]: # ✅ Union[Tuple[str, str], None]으로 수정
+    """
+    Clova Studio API를 호출하여 팀 프로젝트 역할 추천을 받습니다.
+    OpenAI SDK의 chat.completions.create 메서드를 사용하며,
+    추천 역할과 간략한 추천 이유를 각각 다른 변수에 저장하여 반환합니다.
+    모든 예외 처리가 제거되었습니다.
+
+    Args:
+        prompt (str): 사용자 정보가 담긴 프롬프트.
+        role_types (list[str]): 추천할 역할 종류 리스트.
+
+    Returns:
+        tuple[str, str] | None: (추천 역할, 추천 이유) 튜플 또는 오류 발생 시 None.
+    """
+    role_list_str = ", ".join(role_types)
+
+    # LLM에게 특정 JSON 형식으로 응답하도록 지시하는 시스템 메시지
+    system_content = (
+        "너는 팀 프로젝트 역할 추천 AI야. "
+        "사용자가 제공한 역할 종류 중에서 가장 적합한 역할을 추천하고, "
+        "그 이유를 아주 간략한 문장으로 설명해줘. "
+        "응답은 반드시 다음 JSON 형식으로 제공해야 해: "
+        '{"recommendedRole": "추천 역할", "reason": "간략한 추천 이유"}.'
+    )
+
+    # LLM에게 전달할 사용자 메시지
+    user_content = f"{prompt}\n추천할 역할 종류는 다음과 같아: {role_list_str}"
+
+    # OpenAI SDK를 사용하여 Chat Completions API 호출
+    response = client.chat.completions.create(
+        model="HCX-005",  # 사용하려는 Clova Studio 모델명 (예: HCX-005)
+        messages=[
+            {"role": "system", "content": system_content},
+            {"role": "user", "content": user_content}
         ],
-        "topP": 0.8,
-        "temperature": 0.7,
-        "maxTokens": 200
-    }
+        top_p=0.8,
+        temperature=0.7,
+        max_tokens=200,
+        # ✅ response_format={"type": "json_object"} 제거
+    )
 
-    response = requests.post(CLOVA_API_URL, headers=headers, json=payload)
-    if response.status_code != 200:
-        print("❌ Clova 호출 실패:", response.status_code, response.text)
-        raise Exception(f"Clova 오류: {response.status_code} {response.text}")
+    # 응답에서 메시지 내용 추출 및 JSON 파싱
+    if response.choices and response.choices[0].message and response.choices[0].message.content:
+        response_text = response.choices[0].message.content
+        # 예외 처리가 제거되었으므로, JSON 파싱 실패 시 오류가 발생합니다.
+        parsed_response = json.loads(response_text)
+        recommended_role = parsed_response.get("recommendedRole")
+        reason = parsed_response.get("reason")
 
-    return response.json()
+        if recommended_role and reason:
+            return recommended_role, reason
+        else:
+            # 필드가 누락되었을 경우의 처리 (예외 처리가 없으므로 None 반환)
+            print("❌ Clova 응답 JSON에 'recommendedRole' 또는 'reason' 필드가 누락되었습니다.")
+            return None
+    else:
+        # 유효한 메시지 내용이 없을 경우의 처리 (예외 처리가 없으므로 None 반환)
+        print("❌ Clova 응답에 유효한 메시지 내용이 없습니다.")
+        return None
+
 
 def make_prompt(major, traits, preferences):
     trait_str = ", ".join(traits)

--- a/static/js/pages/main/roles.js
+++ b/static/js/pages/main/roles.js
@@ -2,21 +2,23 @@
 
 // 전역 변수
 let currentTeamId = null;
-let currentAIResult = null;
+let currentAIResult = null; // AI 추천 결과를 저장할 변수 (수정된 형식에 맞게 사용)
 
 // 페이지 로드 시 초기화
 document.addEventListener('DOMContentLoaded', function() {
     console.log('역할 관리 페이지 초기화');
-    
+
     // URL에서 팀 ID 추출
     const pathParts = window.location.pathname.split('/');
-    currentTeamId = pathParts[1]; // /9/roles/ 형태에서 9 추출
-    
+    // /<team_id>/roles/ 형태에서 team_id 추출
+    // pathParts[0]은 빈 문자열, pathParts[1]이 team_id
+    currentTeamId = pathParts[1];
+
     setupEventListeners();
-    
+
     // 기본적으로 AI 추천 탭 활성화
     switchTab('ai-recommend');
-    
+
     // 등록된 역할이 있는지 확인하고 UI 상태 업데이트
     const roleItems = document.querySelectorAll('.role-item');
     if (roleItems.length > 0) {
@@ -33,7 +35,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 });
 
-// 페이지 초기화
+// 페이지 초기화 (DOMContentLoaded에서 이미 처리되므로 중복될 수 있음)
 function initializeRolesPage() {
     // 현재 팀 ID 가져오기
     const pathParts = window.location.pathname.split('/');
@@ -41,7 +43,7 @@ function initializeRolesPage() {
 
     // 이벤트 리스너 등록
     setupEventListeners();
-    
+
     // 초기 탭 설정
     showTab('ai-recommend');
 }
@@ -71,7 +73,7 @@ function setupEventListeners() {
     if (closeModalBtn) {
         closeModalBtn.addEventListener('click', closeRoleModal);
     }
-    
+
     if (cancelBtn) {
         cancelBtn.addEventListener('click', closeRoleModal);
     }
@@ -103,19 +105,19 @@ function switchTab(tabName) {
     document.querySelectorAll('.tab-btn').forEach(btn => {
         btn.classList.remove('active');
     });
-    
+
     // 모든 탭 콘텐츠 숨기기
     document.querySelectorAll('.tab-content').forEach(content => {
         content.classList.remove('active');
     });
-    
+
     // 선택된 탭 활성화
     const selectedBtn = document.querySelector(`[data-tab="${tabName}"]`);
     const selectedContent = document.getElementById(tabName);
-    
+
     if (selectedBtn) selectedBtn.classList.add('active');
     if (selectedContent) selectedContent.classList.add('active');
-    
+
     // AI 추천 탭으로 전환할 때 상태 업데이트
     if (tabName === 'ai-recommend') {
         updateAITabState();
@@ -126,7 +128,7 @@ function switchTab(tabName) {
 function updateAITabState() {
     const roleItems = document.querySelectorAll('.role-item');
     const hasRoles = roleItems.length > 0;
-    
+
     if (hasRoles) {
         // 역할이 있으면 빈 알림 숨기고 AI 폼 표시
         hideEmptyRolesInAITab();
@@ -144,17 +146,17 @@ function showTab(tabName) {
 // AI 추천 처리
 async function handleAIRecommendation(e) {
     e.preventDefault();
-    
+
     const formData = new FormData(e.target);
     const traits = formData.getAll('traits');
-    const preferredRoles = formData.getAll('preferred_roles');
+    const preferredRoles = formData.getAll('preferred_roles'); // preferred_roles는 roleId 값
     const major = formData.get('major');
-    
+
     if (traits.length === 0) {
         showNotification('성향을 하나 이상 선택해주세요.', 'error');
         return;
     }
-    
+
     try {
         // AI 추천 요청
         const response = await fetch('/roles/ai-recommend-role/', {
@@ -166,26 +168,29 @@ async function handleAIRecommendation(e) {
             body: JSON.stringify({
                 major: major,
                 traits: traits,
-                preferred_roles: preferredRoles
+                preferred_roles: preferredRoles // ✅ 다시 활성화하여 백엔드로 전달
             })
         });
-        
+
         const data = await response.json();
-        
+
         if (response.ok) {
-            // AI 결과 표시
-            showAIResult(data.recommendation);
+            // ✅ AI 결과 표시: 백엔드에서 반환하는 data 객체 전체를 전달
+            showAIResult(data);
         } else {
-            // AI API 오류 시 더미 결과 사용
+            // AI API 오류 시 더미 결과 사용 (오류 메시지 포함)
+            console.error('AI API 오류 응답:', data.error || response.statusText);
             const dummyResult = generateDummyAIResult(major, traits, preferredRoles);
             showAIResult(dummyResult);
+            showNotification(data.error || 'AI 추천 중 오류가 발생했습니다.', 'error');
         }
-        
+
     } catch (error) {
-        console.error('AI 추천 오류:', error);
+        console.error('AI 추천 요청 중 네트워크 오류:', error);
         // 오류 시에도 더미 결과 사용
         const dummyResult = generateDummyAIResult(major, traits, preferredRoles);
         showAIResult(dummyResult);
+        showNotification('AI 추천 요청 중 네트워크 오류가 발생했습니다.', 'error');
     }
 }
 
@@ -193,13 +198,14 @@ async function handleAIRecommendation(e) {
 function generateDummyAIResult(major, traits, preferredRoles) {
     const roleNames = ['프론트엔드 개발자', '백엔드 개발자', 'UI/UX 디자이너', '프로젝트 매니저', '데이터 분석가', 'QA 엔지니어'];
     const randomRole = roleNames[Math.floor(Math.random() * roleNames.length)];
-    
+
     const traitText = traits.join(', ');
     const preferredText = preferredRoles.length > 0 ? `선호 역할: ${preferredRoles.join(', ')}` : '';
-    
+
+    // ✅ 더미 결과도 백엔드 응답 형식에 맞게 수정
     return {
-        role_name: randomRole,
-        description: `${major} 전공자로서 ${traitText}한 성향을 보이는 당신에게 "${randomRole}" 역할을 추천합니다. ${preferredText} ${traitText}한 특성을 활용하여 팀 프로젝트에서 뛰어난 성과를 낼 수 있을 것입니다.`
+        recommended_role: randomRole,
+        reason: `${major} 전공자로서 ${traitText}한 성향을 보이는 당신에게 "${randomRole}" 역할을 추천합니다. ${preferredText} ${traitText}한 특성을 활용하여 팀 프로젝트에서 뛰어난 성과를 낼 수 있을 것입니다.`
     };
 }
 
@@ -207,27 +213,26 @@ function generateDummyAIResult(major, traits, preferredRoles) {
 function showAIResult(result) {
     const resultContainer = document.getElementById('ai-result');
     const resultContent = document.getElementById('ai-result-content');
-    const recommendedRoleName = document.getElementById('recommended-role-name');
-    
-    if (resultContainer && resultContent && recommendedRoleName) {
-        // 결과 내용 설정
-        if (typeof result === 'string') {
-            // 문자열 형태의 결과 처리
-            const roleMatch = result.match(/추천 역할:\s*([^\n]+)/);
-            const roleName = roleMatch ? roleMatch[1].trim() : '추천 역할';
-            const description = result.replace(/추천 역할:\s*[^\n]+\n?/, '').trim();
-            
-            recommendedRoleName.textContent = roleName;
-            resultContent.textContent = description;
-        } else {
-            // 객체 형태의 결과 처리
-            recommendedRoleName.textContent = result.role_name || '추천 역할';
-            resultContent.textContent = result.description || result;
-        }
-        
+    const recommendedRoleNameElement = document.getElementById('recommended-role-name'); // 변수명 변경
+
+    if (resultContainer && resultContent && recommendedRoleNameElement) {
+        // ✅ 객체 형태의 결과 처리 (백엔드에서 오는 데이터 형식)
+        // result는 { recommended_role: "...", reason: "..." } 형태
+        const recommendedRole = result.recommended_role;
+        const reason = result.reason;
+
+        // ✅ 전역 변수에 AI 추천 결과 저장 (수락 버튼에서 사용)
+        currentAIResult = {
+            name: recommendedRole,
+            description: reason // 이유를 설명으로 사용
+        };
+
+        recommendedRoleNameElement.textContent = recommendedRole || '추천 역할';
+        resultContent.textContent = reason || '추천 이유를 불러올 수 없습니다.';
+
         // 결과 컨테이너 표시
         resultContainer.classList.remove('hidden');
-        
+
         // 스크롤을 결과로 이동
         resultContainer.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     }
@@ -235,17 +240,14 @@ function showAIResult(result) {
 
 // AI 역할 수락
 async function acceptAIRole() {
-    const aiResult = document.getElementById('ai-result-content');
-    const recommendedRoleName = document.getElementById('recommended-role-name');
-    
-    if (!aiResult || !recommendedRoleName) {
+    if (!currentAIResult || !currentAIResult.name) {
         showNotification('추천 결과를 찾을 수 없습니다.', 'error');
         return;
     }
 
-    const roleName = recommendedRoleName.textContent.trim();
-    const roleDescription = aiResult.textContent.trim();
-    
+    const roleName = currentAIResult.name;
+    const roleDescription = currentAIResult.description; // AI 추천 이유를 설명으로 사용
+
     try {
         // 1. 먼저 역할을 등록
         const createResponse = await fetch(`/api/dashboard/${currentTeamId}/roles/create/`, {
@@ -256,13 +258,13 @@ async function acceptAIRole() {
             },
             body: JSON.stringify({
                 name: roleName,
-                description: roleDescription,
+                description: roleDescription, // 설명 필드 추가
                 is_ai_generated: true
             })
         });
 
         const createData = await createResponse.json();
-        
+
         if (!createResponse.ok) {
             throw new Error(createData.error || '역할 등록 실패');
         }
@@ -282,26 +284,26 @@ async function acceptAIRole() {
         });
 
         const assignData = await assignResponse.json();
-        
+
         if (!assignResponse.ok) {
             throw new Error(assignData.error || '역할 할당 실패');
         }
 
         showNotification(`AI 추천 역할이 수락되었습니다: ${roleName}`, 'success');
-        
+
         // 3. UI 업데이트
         // 역할 목록에 추가
         addRoleToList(createData.role);
-        
+
         // 팀원 현황 업데이트 (현재 사용자)
         updateMemberStatus(window.currentUserId || getCurrentUserId(), assignData.assignment);
-        
+
         // 대시보드 팀 현황 업데이트
         updateDashboardTeamStatus();
-        
+
         // AI 결과 숨기기
         hideAIResult();
-        
+
     } catch (error) {
         console.error('AI 역할 수락 오류:', error);
         showNotification(error.message || 'AI 역할 수락 중 오류가 발생했습니다.', 'error');
@@ -323,7 +325,7 @@ function getCurrentUserId() {
     if (userIdMeta) {
         return parseInt(userIdMeta.getAttribute('content'));
     }
-    
+
     // 팀원 목록에서 현재 사용자 찾기 (fallback)
     const memberItems = document.querySelectorAll('.member-assignment-item');
     for (let item of memberItems) {
@@ -332,7 +334,7 @@ function getCurrentUserId() {
             return parseInt(userId);
         }
     }
-    
+
     return null;
 }
 
@@ -341,13 +343,13 @@ function openRoleModal() {
     const modal = document.getElementById('role-modal');
     if (modal) {
         modal.classList.remove('hidden');
-        
+
         // 폼 초기화
         const form = document.getElementById('role-form');
         if (form) {
             form.reset();
         }
-        
+
         // 첫 번째 입력 필드에 포커스
         const nameInput = document.getElementById('role-name');
         if (nameInput) {
@@ -367,13 +369,13 @@ function closeRoleModal() {
 // 역할 생성 처리
 async function handleRoleCreation(e) {
     e.preventDefault();
-    
+
     const formData = new FormData(e.target);
     const roleData = {
         name: formData.get('name').trim(),
-        description: '' // 설명 필드 제거됨
+        description: formData.get('description') ? formData.get('description').trim() : '' // 설명 필드 다시 추가됨
     };
-    
+
     if (!roleData.name) {
         showNotification('역할명을 입력해주세요.', 'error');
         return;
@@ -390,24 +392,20 @@ async function handleRoleCreation(e) {
         });
 
         const data = await response.json();
-        
+
         if (response.ok) {
             showNotification('새 역할이 등록되었습니다!', 'success');
             closeRoleModal();
-            
+
             // 역할 목록 업데이트 (새로고침 없이)
             addRoleToList(data.role);
-            
-            // 직접입력 탭 유지 - 자동 전환 제거
-            // switchTab('ai-recommend'); // 제거됨
-            
+
             // AI 탭 상태 업데이트는 사용자가 AI 탭을 클릭할 때 처리
-            // hideEmptyRolesInAITab(); // 제거됨
-            
+            // showAIFormAfterRoleCreation()은 addRoleToList 내부에서 호출되므로 여기서 제거
         } else {
             throw new Error(data.error || '역할 등록 실패');
         }
-        
+
     } catch (error) {
         console.error('역할 생성 오류:', error);
         showNotification(error.message || '역할 등록 중 오류가 발생했습니다.', 'error');
@@ -429,47 +427,47 @@ async function deleteRole(roleId) {
         });
 
         const data = await response.json();
-        
+
         if (response.ok) {
             showNotification('역할이 삭제되었습니다.', 'success');
-            
+
             // 1. 역할 목록에서 제거
             const roleItem = document.querySelector(`[data-role-id="${roleId}"]`);
             if (roleItem) {
                 roleItem.remove();
             }
-            
+
             // 2. 해당 역할이 할당된 팀원들을 미정으로 변경
             updateMembersWithDeletedRole(roleId);
-            
+
             // 3. 빈 상태 확인 및 처리
             const rolesList = document.getElementById('roles-list');
             if (rolesList && rolesList.children.length === 0) {
                 rolesList.innerHTML = '<div class="empty-roles"><p>등록된 역할이 없습니다.</p></div>';
-                
+
                 // AI 추천 탭도 빈 상태로 변경 (AI 탭이 활성화된 경우에만)
                 const aiTab = document.getElementById('ai-recommend');
                 if (aiTab && aiTab.classList.contains('active')) {
                     showEmptyRolesInAITab();
                 }
-                
+
                 // 팀원 역할 지정 섹션 숨기기
                 hideTeamRoleAssignmentSection();
             } else {
                 // 4. 드롭다운 옵션 업데이트
                 updateRoleSelectOptions();
             }
-            
+
             // 5. 선호 역할에서도 제거
             updateAllPreferredRoles();
-            
+
             // 6. 대시보드 팀 현황 업데이트
             updateDashboardTeamStatus();
-            
+
         } else {
             throw new Error(data.error || '역할 삭제 실패');
         }
-        
+
     } catch (error) {
         console.error('역할 삭제 오류:', error);
         showNotification('역할 삭제 중 오류가 발생했습니다.', 'error');
@@ -490,7 +488,7 @@ function updateMembersWithDeletedRole(deletedRoleId) {
             assignedRoleElement.replaceWith(noRoleElement);
         }
     });
-    
+
     // 역할 지정 드롭다운들 초기화
     const roleSelects = document.querySelectorAll('.role-select');
     roleSelects.forEach(select => {
@@ -503,15 +501,16 @@ function updateMembersWithDeletedRole(deletedRoleId) {
 // AI 추천 탭에 빈 역할 알림 표시
 function showEmptyRolesInAITab() {
     const aiSection = document.querySelector('#ai-recommend .ai-section');
-    const aiFormContainer = document.querySelector('.ai-form-container');
+    let aiFormContainer = document.querySelector('.ai-form-container'); // let으로 변경
     const emptyNotice = document.querySelector('.empty-roles-notice');
-    
+
     if (aiSection) {
-        // 기존 AI 폼 제거
+        // 기존 AI 폼 제거 (존재한다면)
         if (aiFormContainer) {
             aiFormContainer.remove();
+            aiFormContainer = null; // 제거 후 null로 설정
         }
-        
+
         // 빈 역할 알림이 없으면 생성
         if (!emptyNotice) {
             const emptyNoticeHTML = `
@@ -549,11 +548,13 @@ function hideEmptyRolesInAITab() {
 function showAIFormAfterRoleCreation() {
     const aiSection = document.querySelector('.ai-section');
     const emptyNotice = document.querySelector('.empty-roles-notice');
-    
-    if (emptyNotice && aiSection) {
+
+    if (aiSection) { // aiSection이 존재하는지 확인
         // 빈 알림 숨기기
-        emptyNotice.style.display = 'none';
-        
+        if (emptyNotice) {
+            emptyNotice.style.display = 'none';
+        }
+
         // AI 폼 컨테이너가 없으면 생성
         let aiFormContainer = document.querySelector('.ai-form-container');
         if (!aiFormContainer) {
@@ -627,16 +628,19 @@ function showAIFormAfterRoleCreation() {
                     </div>
                 </div>
             `;
-            
+
             aiSection.appendChild(aiFormContainer);
-            
+
             // 새로운 폼에 이벤트 리스너 추가
             const newForm = aiFormContainer.querySelector('#ai-recommendation-form');
             if (newForm) {
                 newForm.addEventListener('submit', handleAIRecommendation);
             }
+        } else {
+            // 이미 AI 폼 컨테이너가 있으면 다시 표시
+            aiFormContainer.style.display = 'block';
         }
-        
+
         // 선호 역할 목록 업데이트
         updateAllPreferredRoles();
     }
@@ -645,13 +649,13 @@ function showAIFormAfterRoleCreation() {
 // 역할 리스트에 새 역할 추가 (새로고침 없이)
 function addRoleToList(role) {
     const rolesList = document.getElementById('roles-list');
-    
+
     // 빈 상태 메시지 제거
     const emptyMessage = rolesList.querySelector('.empty-roles');
     if (emptyMessage) {
         emptyMessage.remove();
     }
-    
+
     // 새 역할 아이템 생성
     const roleItem = document.createElement('div');
     roleItem.className = 'role-item';
@@ -664,57 +668,60 @@ function addRoleToList(role) {
             </svg>
         </button>
     `;
-    
+
     rolesList.appendChild(roleItem);
-    
+
     // 선호 역할 체크박스 업데이트
     updateAllPreferredRoles();
-    
+
     // 드롭다운 옵션 업데이트
     updateRoleSelectOptions();
-    
+
     // 팀원 역할 지정 섹션 표시
     showTeamRoleAssignmentSection();
+
+    // 역할이 추가되면 AI 폼을 표시하도록 호출
+    showAIFormAfterRoleCreation();
 }
 
-// 선호 역할 목록 업데이트
-function updatePreferredRoles(role) {
-    const preferredRoles = document.querySelector('.preferred-roles');
-    if (preferredRoles) {
-        const checkboxItem = document.createElement('label');
-        checkboxItem.className = 'checkbox-item';
-        checkboxItem.innerHTML = `
-            <input type="checkbox" name="preferred_roles" value="${role.name}">
-            <span>${role.name}</span>
-        `;
-        preferredRoles.appendChild(checkboxItem);
-    }
-}
+// 선호 역할 목록 업데이트 (개별 역할 추가 시 사용되지 않음, updateAllPreferredRoles로 대체됨)
+// function updatePreferredRoles(role) {
+//     const preferredRoles = document.querySelector('.preferred-roles');
+//     if (preferredRoles) {
+//         const checkboxItem = document.createElement('label');
+//         checkboxItem.className = 'checkbox-item';
+//         checkboxItem.innerHTML = `
+//             <input type="checkbox" name="preferred_roles" value="${role.name}">
+//             <span>${role.name}</span>
+//         `;
+//         preferredRoles.appendChild(checkboxItem);
+//     }
+// }
 
 // 모든 선호 역할 체크박스 업데이트
 function updateAllPreferredRoles() {
-    const preferredRolesContainer = document.getElementById('preferred-roles');
+    const preferredRolesContainer = document.getElementById('preferred-roles-container'); // ID 수정
     if (!preferredRolesContainer) return;
-    
+
     // 기존 체크박스들 제거
     preferredRolesContainer.innerHTML = '';
-    
+
     // 등록된 역할들로 체크박스 재생성
     const roleItems = document.querySelectorAll('.role-item');
     roleItems.forEach(item => {
         const roleName = item.querySelector('.role-name').textContent;
         const roleId = item.dataset.roleId;
-        
+
         const checkboxWrapper = document.createElement('label');
         checkboxWrapper.className = 'checkbox-item';
         checkboxWrapper.innerHTML = `
             <input type="checkbox" name="preferred_roles" value="${roleId}">
             <span class="checkbox-label">${roleName}</span>
         `;
-        
+
         preferredRolesContainer.appendChild(checkboxWrapper);
     });
-    
+
     // 역할이 없으면 안내 메시지 표시
     if (roleItems.length === 0) {
         preferredRolesContainer.innerHTML = '<p class="no-roles-message">등록된 역할이 없습니다. 먼저 역할을 등록해주세요.</p>';
@@ -722,26 +729,22 @@ function updateAllPreferredRoles() {
 }
 
 
-
-
-
 // 팀원 현황 업데이트
 function updateMemberStatus(userId, assignment) {
     // 팀원 현황 카드 찾기 및 업데이트
     const memberCards = document.querySelectorAll('.member-status-card');
     memberCards.forEach(card => {
-        const memberName = card.querySelector('h4').textContent.trim();
-        const assignmentUserName = assignment.user || '';
-        
-        if (memberName === assignmentUserName || card.dataset.userId === userId.toString()) {
+        // user_id를 기반으로 카드 찾기
+        if (card.dataset.userId === userId.toString()) {
             let assignedRoleElement = card.querySelector('.assigned-role, .no-role, .multiple-roles');
-            
+
             if (!assignedRoleElement) {
                 // 기존 역할 표시 요소가 없으면 새로 생성
                 assignedRoleElement = document.createElement('div');
                 card.appendChild(assignedRoleElement);
             }
-            
+
+            // '역할 없음' 또는 null/undefined일 경우 '역할 미정'으로 표시
             if (assignment.role && assignment.role !== '역할 없음') {
                 assignedRoleElement.className = `assigned-role ${assignment.is_ai_assigned ? 'ai-assigned' : ''}`;
                 assignedRoleElement.dataset.roleId = assignment.role_id || ''; // role ID 저장
@@ -754,7 +757,7 @@ function updateMemberStatus(userId, assignment) {
                 assignedRoleElement.textContent = '역할 미정';
                 delete assignedRoleElement.dataset.roleId; // role ID 제거
             }
-            
+
             // 팀장인 경우 팀장 표시도 유지 (팀장 = team.owner)
             const teamRole = card.querySelector('.team-role');
             if (teamRole && teamRole.textContent.includes('팀장')) {
@@ -777,7 +780,7 @@ function updateMemberStatus(userId, assignment) {
 async function assignRole(userId) {
     const roleSelect = document.querySelector(`select[data-user-id="${userId}"]`);
     const roleId = roleSelect.value;
-    
+
     if (!roleId) {
         showNotification('역할을 선택해주세요.', 'error');
         return;
@@ -798,20 +801,20 @@ async function assignRole(userId) {
         });
 
         const data = await response.json();
-        
+
         if (response.ok) {
             showNotification(`역할이 할당되었습니다: ${data.assignment.role}`, 'success');
-            
+
             // 팀원 현황 업데이트
             updateMemberStatus(userId, data.assignment);
-            
+
             // 대시보드 팀 현황도 업데이트
             updateDashboardTeamStatus();
-            
+
         } else {
             throw new Error(data.error || '역할 할당 실패');
         }
-        
+
     } catch (error) {
         console.error('역할 할당 오류:', error);
         showNotification(error.message || '역할 할당 중 오류가 발생했습니다.', 'error');
@@ -848,7 +851,7 @@ function showNotification(message, type = 'info') {
     if (existingNotification) {
         existingNotification.remove();
     }
-    
+
     // 새 알림 생성
     const notification = document.createElement('div');
     notification.className = `notification notification-${type}`;
@@ -865,7 +868,7 @@ function showNotification(message, type = 'info') {
         transform: translateX(100%);
         transition: all 0.3s ease;
     `;
-    
+
     // 타입별 배경색
     const colors = {
         success: '#10b981',
@@ -873,18 +876,18 @@ function showNotification(message, type = 'info') {
         info: '#3b82f6',
         warning: '#f59e0b'
     };
-    
+
     notification.style.backgroundColor = colors[type] || colors.info;
     notification.textContent = message;
-    
+
     document.body.appendChild(notification);
-    
+
     // 애니메이션으로 표시
     setTimeout(() => {
         notification.style.opacity = '1';
         notification.style.transform = 'translateX(0)';
     }, 10);
-    
+
     // 3초 후 자동 제거
     setTimeout(() => {
         notification.style.opacity = '0';
@@ -923,13 +926,13 @@ function showTeamRoleAssignmentSection() {
 function updateRoleSelectOptions() {
     const roleSelects = document.querySelectorAll('.role-select');
     const roleItems = document.querySelectorAll('.role-item');
-    
+
     roleSelects.forEach(select => {
         // 기존 옵션 제거 (첫 번째 "역할 선택" 옵션 제외)
         while (select.children.length > 1) {
             select.removeChild(select.lastChild);
         }
-        
+
         // 현재 역할들로 옵션 재생성
         roleItems.forEach(item => {
             const roleName = item.querySelector('.role-name').textContent;
@@ -941,6 +944,3 @@ function updateRoleSelectOptions() {
         });
     });
 }
-
-
-

--- a/teamflow/settings.py
+++ b/teamflow/settings.py
@@ -296,3 +296,9 @@ environ.Env.read_env()
 # 환경변수 의존성 제거하여 roles/clova_ai.py에서 직접 관리하도록 변경
 # CLOVA_API_KEY = env("CLOVA_API_KEY")  # 제거됨
 # ========================================
+NCP_API_URL = env('NCP_API_URL')
+NCP_CLOVASTUDIO_API_KEY = env('NCP_CLOVASTUDIO_API_KEY')
+NCP_APIGW_API_KEY = env('NCP_APIGW_API_KEY')
+
+NCP_ACCESS_KEY = env('NCP_ACCESS_KEY')
+NCP_SECRET_KEY = env('NCP_SECRET_KEY')


### PR DESCRIPTION
### AI 역할 추천 기능 구현했습니다!
- 기존의 API GateWay 사용 방식이 아닌, OpenAI가 제공하는 SDK 방식으로 구현했습니다.
- Clova Studio의 HCX-005 모델을 사용하도록 설정했으며 추천 받을 시 토큰이 올라가는 부분도 확인했습니다.
- 기존의 .env 파일에서 사용안되는 키들이 많지만 우선 놔두고 추가해야 할 키 추가해서 Notion에 작성해 두었습니다.