### PR TITLE
팀 관리 API 추가: 팀 삭제 및 탈퇴 기능 구현, 관련 URL 패턴 정의 및 프론트엔드에서의 삭제/탈퇴 처리 로직 추가

### DIFF
--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -23,4 +23,8 @@ urlpatterns = [
 
     # 일정 페이지
     path('<int:team_id>/calendar/', schedule_views.calendar_page_view, name='calendar_page'),
+
+    # 팀 관리 API (삭제/탈퇴)
+    path('<int:team_id>/team/delete/', views.TeamDeleteAPIView.as_view(), name='team_delete_api'),
+    path('<int:team_id>/team/leave/', views.TeamLeaveAPIView.as_view(), name='team_leave_api'),
 ]

--- a/static/css/pages/main/team_log.css
+++ b/static/css/pages/main/team_log.css
@@ -127,6 +127,48 @@
     transform: translateY(0);
 }
 
+/* 보조 버튼: 숨기기 */
+.btn-secondary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: .5rem;
+    padding: .75rem 1rem;
+    background: #eef2f7;
+    color: var(--text-1);
+    border: 1px solid #e1e5e9;
+    border-radius: var(--radius);
+    font-size: .875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all var(--transition-1);
+}
+
+.btn-secondary:hover {
+    background: #e9edf2;
+}
+
+/* 위험 동작 버튼: 삭제 */
+.btn-danger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: .5rem;
+    padding: .75rem 1rem;
+    background: #fee2e2;
+    color: #b91c1c;
+    border: 1px solid #fecaca;
+    border-radius: var(--radius);
+    font-size: .875rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all var(--transition-1);
+}
+
+.btn-danger:hover {
+    background: #fecaca;
+}
+
 /* 빈 상태 */
 .empty-state {
     text-align: center;

--- a/static/js/pages/main/team_log.js
+++ b/static/js/pages/main/team_log.js
@@ -32,6 +32,49 @@ document.addEventListener('DOMContentLoaded', function() {
     // 전역 노출(상세 페이지에서도 쓰게)
     window.TeamLogLocalHide = TeamLogLocalHide;
 
+    // ===== 프로젝트 카드 로컬 삭제 (팀 기록 카드용) =====
+    const DeletedProjects = (() => {
+        const NEW_KEY = 'teamlog_deleted_projects';
+        const OLD_KEY = 'teamlog_hidden_projects'; // 이전 버전 호환
+
+        function getDeletedSet() {
+            // 마이그레이션: 예전에 저장된 숨김 목록이 있으면 합침
+            let fromNew = [];
+            let fromOld = [];
+            try { fromNew = JSON.parse(localStorage.getItem(NEW_KEY) || '[]'); } catch { fromNew = []; }
+            try { fromOld = JSON.parse(localStorage.getItem(OLD_KEY) || '[]'); } catch { fromOld = []; }
+            const merged = new Set([...(fromNew || []), ...(fromOld || [])].map(String));
+            if (fromOld && fromOld.length) {
+                localStorage.removeItem(OLD_KEY);
+                localStorage.setItem(NEW_KEY, JSON.stringify([...merged]));
+            }
+            return merged;
+        }
+        function saveDeletedSet(set) {
+            localStorage.setItem(NEW_KEY, JSON.stringify([...set]));
+        }
+        function isDeleted(teamId) {
+            const s = getDeletedSet();
+            return s.has(String(teamId));
+        }
+        function markDeleted(teamId) {
+            const s = getDeletedSet();
+            s.add(String(teamId));
+            saveDeletedSet(s);
+        }
+        function restore(teamId) {
+            const s = getDeletedSet();
+            s.delete(String(teamId));
+            saveDeletedSet(s);
+        }
+        function filter(projects) {
+            const s = getDeletedSet();
+            return (projects || []).filter(p => !s.has(String(p.team_id)));
+        }
+        return { getDeletedSet, saveDeletedSet, isDeleted, markDeleted, restore, filter };
+    })();
+    window.TeamLogDeletedProjects = DeletedProjects;
+
     // ===== 탭 해시 제거 (탭이 있을 때만 동작; 없으면 조용히 패스) =====
     (function initTabWithoutHash(){
         const tabs = document.querySelectorAll('.tab[data-tab], .tab[href^="#"]');
@@ -73,11 +116,12 @@ document.addEventListener('DOMContentLoaded', function() {
         try {
             showLoadingState();
             const teamProjects = await fetchTeamProjects();
+            const visibleProjects = DeletedProjects.filter(teamProjects);
             
-            if (teamProjects.length === 0) {
+            if (visibleProjects.length === 0) {
                 showEmptyState();
             } else {
-                renderTeamProjects(teamProjects);
+                renderTeamProjects(visibleProjects);
                 showProjectsGrid();
             }
         } catch (error) {
@@ -106,7 +150,7 @@ document.addEventListener('DOMContentLoaded', function() {
      * 팀 프로젝트 카드들 렌더링
      */
     function renderTeamProjects(projects) {
-        const projectsHTML = projects.map(project => createProjectCard(project)).join('');
+        const projectsHTML = (projects || []).map(project => createProjectCard(project)).join('');
         teamProjectsGrid.innerHTML = projectsHTML;
     }
 
@@ -130,7 +174,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const dashboardUrl = project.dashboard_url || `/api/dashboard/${project.team_id}/`;
 
         return `
-            <div class="project-card">
+            <div class="project-card" data-team-id="${project.team_id}">
                 <div class="project-card-header">
                     <div>
                         <h3 class="project-title">${escapeHtml(project.title)}</h3>
@@ -177,6 +221,12 @@ document.addEventListener('DOMContentLoaded', function() {
                         </svg>
                         프로젝트 보기
                     </a>
+                    <button type="button" class="btn-danger project-delete-btn" title="이 팀 삭제/탈퇴">
+                        <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M9 7V5a2 2 0 012-2h2a2 2 0 012 2v2m-9 0h10"></path>
+                        </svg>
+                        삭제/탈퇴
+                    </button>
                 </div>
             </div>
         `;
@@ -259,5 +309,71 @@ document.addEventListener('DOMContentLoaded', function() {
             showErrorState
         };
         console.log('🔧 TeamLog 디버그 함수들이 window.TeamLogDebug에 노출되었습니다.');
+    }
+
+    // ===== 이벤트 위임: 카드 숨기기 처리 =====
+    document.addEventListener('click', async (e) => {
+        const btn = e.target.closest('.project-delete-btn');
+        if (!btn) return;
+
+        const card = btn.closest('.project-card');
+        const teamId = card?.dataset?.teamId;
+        if (!card || !teamId) return;
+
+        // 백엔드에서 현재 사용자의 팀 소유 여부를 헤더를 통해 가져올 수 있으나,
+        // 카드 데이터에는 없으므로 확인 팝업에서 분기 선택 제공
+        const choice = await promptDeleteOrLeave();
+        if (!choice) return;
+
+        const confirmMsg = choice === 'delete'
+            ? '정말 팀을 삭제하시겠어요?\n삭제 후 복구할 수 없습니다. (팀장만 가능)'
+            : '정말 팀에서 탈퇴하시겠어요?\n탈퇴 후 복구할 수 없습니다.';
+        if (!window.confirm(confirmMsg)) return;
+
+        try {
+            // 로딩 표시(optional)
+            if (window.showLoading) window.showLoading('처리 중입니다...');
+
+            const url = choice === 'delete'
+                ? `/api/dashboard/${teamId}/team/delete/`
+                : `/api/dashboard/${teamId}/team/leave/`;
+
+            const method = choice === 'delete' ? 'DELETE' : 'POST';
+            const res = await fetch(url, {
+                method,
+                credentials: 'same-origin',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': (window.getCsrfToken?.() || document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '')
+                }
+            });
+
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok || data?.success === false) {
+                throw new Error(data?.error || `요청 실패 (HTTP ${res.status})`);
+            }
+
+            // 성공: 로컬 삭제표시 + DOM 제거
+            DeletedProjects.markDeleted(teamId);
+            card.remove();
+            if (window.showSuccess) window.showSuccess('처리되었습니다.');
+
+            const hasCards = !!teamProjectsGrid.querySelector('.project-card');
+            if (!hasCards) {
+                showEmptyState();
+            }
+        } catch (err) {
+            console.error('팀 삭제/탈퇴 실패:', err);
+            if (window.showError) window.showError(err.message || '처리에 실패했습니다.');
+        } finally {
+            if (window.hideLoading) window.hideLoading();
+        }
+    });
+
+    function promptDeleteOrLeave() {
+        // 간단 분기: 확인 창 2단계 대신 기본 confirm을 두 번 사용
+        // 1) 팀 삭제 시도? (팀장만 가능)
+        const wantDelete = window.confirm('팀 전체를 삭제하시려면 확인을 누르세요.\n팀에서 탈퇴만 하시려면 취소를 누르세요.');
+        return wantDelete ? 'delete' : 'leave';
     }
 });

--- a/teams/urls.py
+++ b/teams/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path('list/', views.UserTeamsAPIView.as_view(), name='user_teams_api'),
     path('current/', views.CurrentTeamAPIView.as_view(), name='current_team_api'),
     path('info/<str:invite_code>/', views.TeamInfoAPIView.as_view(), name='team_info_api'),
+    # 팀 관리 API는 dashboard.urls에 정의됨
     # ========================================
     
     # 기존 페이지 뷰 URL 패턴 (제거 - API 방식으로 통합)


### PR DESCRIPTION
## 팀 삭제/탈퇴 기능 구현

### 추가된 기능
- 팀장 전용 팀 삭제 API (`DELETE /api/dashboard/{team_id}/team/delete/`)
- 팀원용 팀 탈퇴 API (`POST /api/dashboard/{team_id}/team/leave/`)
- 팀 기록 페이지에 삭제/탈퇴 버튼 및 처리 로직

### 주요 변경사항
- Backend: 권한 기반 API 엔드포인트 추가
- Frontend: 카드별 삭제/탈퇴 버튼 및 이중 확인 팝업
- URL 구조: 기존 API 패턴과 일관성 유지