### PR TITLE
MGP: 팀 생성 초대 코드 일관성 및 로그인 메시지 디자인 개선

### DIFF
--- a/static/css/common/components.css
+++ b/static/css/common/components.css
@@ -145,7 +145,246 @@ input:focus-visible, textarea:focus-visible, select:focus-visible { outline: non
 /* Empty state */
 .empty { text-align:center; color: var(--muted); padding: 3rem 1rem; }
 
+/* ======================================== */
+/* MGP: 작고 단순한 알림 시스템 */
+/* 백엔드 팀원이 해결해야 할 부분 대신 해결: 눈에 안 띄는 작은 알림 */
+/* ======================================== */
+
+/* 알림 컨테이너 */
+.notifications-container {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 300px;
+  pointer-events: none;
+}
+
+.notifications-container > * {
+  pointer-events: auto;
+}
+
+/* 개별 알림 카드 - 작고 단순하게 */
+.notification {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  position: relative;
+  overflow: hidden;
+  transform: translateX(100%);
+  animation: slideInNotification 0.3s ease-out forwards;
+  font-size: 13px;
+}
+
+/* 상단 얇은 바 */
+.notification::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: #10b981;
+}
+
+/* 성공 알림 스타일 - 심플하고 간결한 디자인 (사진과 동일한 스타일) */
+.notification-success {
+  border-color: #5cb85c;
+  background: #5cb85c;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(92, 184, 92, 0.3);
+  padding: 16px 20px;
+  color: white;
+  font-weight: 500;
+  text-align: center;
+  max-width: 300px;
+  margin: 0 auto;
+}
+
+/* 상단 초록색 바 제거 - 심플한 단일 색상 배경 */
+.notification-success::before {
+  display: none;
+}
+
+/* 성공 알림에서 닫기 버튼 숨기기 */
+.notification-success .notification-close {
+  display: none;
+}
+
+/* 성공 알림 텍스트 색상 - 흰색으로 통일 (심플한 디자인) */
+.notification-success .notification-text,
+.notification-success .notification-text * {
+  color: white !important;
+}
+
+.notification-success .notification-text strong {
+  color: white !important;
+  font-weight: 600;
+}
+
+.notification-success .notification-text .user-email {
+  color: rgba(255, 255, 255, 0.9) !important;
+  font-weight: 400;
+}
+
+/* 오류 알림 스타일 */
+.notification-error {
+  border-color: #fecaca;
+  background: #fef2f2;
+}
+
+.notification-error::before {
+  background: #ef4444;
+}
+
+/* 경고 알림 스타일 */
+.notification-warning {
+  border-color: #fed7aa;
+  background: #fffbeb;
+}
+
+.notification-warning::before {
+  background: #f59e0b;
+}
+
+/* 정보 알림 스타일 */
+.notification-info {
+  border-color: #bfdbfe;
+  background: #eff6ff;
+}
+
+.notification-info::before {
+  background: #3b82f6;
+}
+
+/* 알림 내용 */
+.notification-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+}
+
+/* 텍스트 */
+.notification-text {
+  line-height: 1.4;
+}
+
+.notification-text strong {
+  color: #374151;
+  font-weight: 600;
+  font-size: 13px;
+  display: block;
+  margin-bottom: 2px;
+}
+
+.notification-text .user-email {
+  color: #6b7280;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.3;
+}
+
+/* 닫기 버튼 - 작게 */
+.notification-close {
+  width: 20px;
+  height: 20px;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+  color: #9ca3af;
+  font-size: 14px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  flex-shrink: 0;
+}
+
+.notification-close:hover {
+  background: rgba(255, 255, 255, 0.95);
+  border-color: #d1d5db;
+  color: #6b7280;
+}
+
+/* 애니메이션 - 부드럽게 */
+@keyframes slideInNotification {
+  0% {
+    opacity: 0;
+    transform: translateX(100%);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideOutNotification {
+  0% {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  100% {
+    opacity: 0;
+    transform: translateX(100%);
+  }
+}
+
+/* 자동 숨김 */
+.notification[data-auto-hide="true"] {
+  animation: slideInNotification 0.3s ease-out forwards,
+             slideOutNotification 0.3s ease-out 3s forwards;
+}
+
+/* 호버 효과 - 최소화 */
+.notification:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  transition: all 0.2s ease;
+}
+
+/* 반응형 */
+@media (max-width: 640px) {
+  .notifications-container {
+    top: 12px;
+    right: 12px;
+    left: 12px;
+    max-width: none;
+  }
+  
+  .notification {
+    padding: 10px 14px;
+    font-size: 12px;
+  }
+  
+  .notification-text strong {
+    font-size: 12px;
+  }
+  
+  .notification-text .user-email {
+    font-size: 11px;
+  }
+  
+  .notification-close {
+    width: 18px;
+    height: 18px;
+    font-size: 12px;
+  }
+}
+
+/* ======================================== */
+
 /* Page title + subtitle (unified across tabs) */
 .page-title-group { display:flex; flex-direction:column; gap:.25rem; }
 .page-title { font-size: 1.5rem; font-weight:700; color: var(--text-1); margin:0; }
 .page-subtitle { font-size: .95rem; color: var(--text-2); margin:0; }
+

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -18,4 +18,81 @@
     console.log("디버그 모드 활성화");
     console.log("APP_CONFIG:", window.APP_CONFIG);
   }
+
+  // ========================================
+  // MGP: 단순한 알림 시스템 */
+  // 백엔드 팀원이 해결해야 할 부분 대신 해결: 눈에 안 띄는 작은 알림 */
+  // ========================================
+  
+  // 알림 시스템 초기화
+  function initNotifications() {
+    const notifications = document.querySelectorAll('.notification[data-auto-hide="true"]');
+    
+    notifications.forEach(notification => {
+      // 자동 숨김 (3초 후)
+      setTimeout(() => {
+        if (notification && notification.parentNode) {
+          hideNotification(notification);
+        }
+      }, 3000);
+      
+      // 닫기 버튼 이벤트
+      const closeBtn = notification.querySelector('.notification-close');
+      if (closeBtn) {
+        closeBtn.addEventListener('click', () => {
+          hideNotification(notification);
+        });
+      }
+    });
+  }
+
+  // 알림 숨김 함수
+  function hideNotification(notification) {
+    notification.style.animation = 'slideOutNotification 0.3s ease-out forwards';
+    setTimeout(() => {
+      if (notification && notification.parentNode) {
+        notification.remove();
+      }
+    }, 300);
+  }
+
+  // DOM 로드 완료 시 알림 시스템 초기화
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initNotifications);
+  } else {
+    initNotifications();
+  }
+
+  // 전역 알림 표시 함수
+  window.showNotification = function(message, type = 'info', autoHide = true) {
+    const notificationsContainer = document.getElementById('global-notifications');
+    if (!notificationsContainer) return;
+
+    const notification = document.createElement('div');
+    notification.className = `notification notification-${type}`;
+    notification.setAttribute('data-auto-hide', autoHide);
+    
+    notification.innerHTML = `
+      <div class="notification-content">
+        <div class="notification-text">${message}</div>
+      </div>
+      <button class="notification-close" type="button" aria-label="닫기">&times;</button>
+    `;
+
+    notificationsContainer.appendChild(notification);
+    
+    // 새로 추가된 알림 초기화
+    initNotifications();
+    
+    // 자동 숨김
+    if (autoHide) {
+      setTimeout(() => {
+        if (notification && notification.parentNode) {
+          hideNotification(notification);
+        }
+      }, 3000);
+    }
+  };
+
+  // ========================================
 })();

--- a/teamflow/settings.py
+++ b/teamflow/settings.py
@@ -181,14 +181,35 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/5.2/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'ko-kr'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Asia/Seoul'
 
 USE_I18N = True
 
 USE_TZ = True
 
+# ========================================
+# MGP: Django allauth 메시지 한국어 설정 추가
+# 백엔드 팀원이 해결해야 할 부분 대신 해결: 로그인 성공 메시지 한국어 변환
+# ========================================
+LANGUAGES = [
+    ('ko', '한국어'),
+    ('en', 'English'),
+]
+
+LOCALE_PATHS = [
+    BASE_DIR / 'locale',
+]
+
+# Django 메시지 프레임워크 설정 (allauth 메시지 제어)
+MESSAGE_STORAGE = 'django.contrib.messages.storage.fallback.FallbackStorage'
+
+# allauth 메시지 커스터마이징
+ACCOUNT_EMAIL_VERIFICATION = 'none'
+ACCOUNT_EMAIL_REQUIRED = False
+
+# ========================================
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
@@ -232,7 +253,7 @@ ACCOUNT_EMAIL_VERIFICATION = 'none'
 # MGP: allauth 메시지 비활성화 설정 추가
 # 백엔드 팀원이 해결해야 할 부분 대신 해결: 로그인 성공 메시지 제거
 # ========================================
-# allauth 메시지 비활성화
+# allauth 메시지 완전 비활성화
 ACCOUNT_EMAIL_CONFIRMATION_AUTHENTICATED_REDIRECT_URL = None
 ACCOUNT_EMAIL_CONFIRMATION_ANONYMOUS_REDIRECT_URL = None
 ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION = False
@@ -244,7 +265,7 @@ ACCOUNT_SESSION_REMEMBER = None
 ACCOUNT_SIGNUP_EMAIL_ENTER_TWICE = False
 ACCOUNT_SIGNUP_FORM_CLASS = None
 ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE = False
-ACCOUNT_SIGNUP_REDIRECT_URL = None
+ACCOUNT_SIGNUP_REDIRECT_URL = '/profile-setup/'
 ACCOUNT_TEMPLATE_EXTENSION = 'html'
 #ACCOUNT_USER_DISPLAY = 'allauth.account.utils.user_display'
 ACCOUNT_USER_MODEL_USERNAME_FIELD = 'username'

--- a/teams/views.py
+++ b/teams/views.py
@@ -5,7 +5,6 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework import status
 from .models import Team, TeamMember # ⬅️ TeamMember도 import 해야 합니다.
-import uuid
 
 # ========================================
 # MGP: REST API 엔드포인트 추가
@@ -18,16 +17,24 @@ class TeamCreateAPIView(APIView):
         try:
             name = request.data.get('name')
             description = request.data.get('description', '')
+            # ========================================
+            # MGP: 프론트엔드에서 전달받은 초대 코드 사용
+            # 백엔드 팀원이 해결해야 할 부분 대신 해결: 팀 생성 시 초대 코드 일관성 유지
+            # ========================================
+            invite_code = request.data.get('invite_code', '')  # 프론트엔드에서 전달받은 초대 코드
             
             if not name:
                 return Response({'error': '팀 이름은 필수입니다.'}, status=status.HTTP_400_BAD_REQUEST)
             
-            # 팀 생성
+            # ========================================
+            # MGP: 팀 생성 시 프론트엔드에서 생성한 초대 코드 사용
+            # 백엔드 팀원이 해결해야 할 부분 대신 해결: 초대 코드 일관성 보장
+            # ========================================
             new_team = Team.objects.create(
                 name=name,
                 description=description,
                 owner=request.user,
-                invite_code=str(uuid.uuid4())[:6].upper()  # 6자리 초대 코드 생성
+                invite_code=invite_code  # 프론트엔드에서 생성한 코드 사용
             )
             
             # 팀 멤버로 추가 (팀장)

--- a/templates/base.html
+++ b/templates/base.html
@@ -48,12 +48,57 @@
 
     <!-- 전역 알림 시스템 -->
     <div id="global-notifications" class="notifications-container">
+      <!-- ======================================== -->
+      <!-- MGP: Django 메시지 시스템 -->
+      <!-- 백엔드 팀원이 해결해야 할 부분 대신 해결: 로그인 성공 메시지 표시 -->
+      <!-- ======================================== -->
+      
+      <!-- Django 메시지 시스템 -->
       {% if messages %}
+        <!-- 디버깅 정보 -->
+        <!-- 현재 URL: {{ request.path }} -->
+        <!-- URL 이름: {{ request.resolver_match.url_name }} -->
+        <!-- 메시지 개수: {{ messages|length }} -->
+        
         {% for message in messages %}
+        <!-- 메시지 내용: {{ message }} -->
+        <!-- 메시지 태그: {{ message.tags }} -->
         <div class="notification notification-{{ message.tags }}" data-auto-hide="true">
-        <span class="notification-text">{{ message }}</span>
+          <!-- ======================================== -->
+          <!-- MGP: allauth 메시지 한국어 변환 및 디자인 개선 -->
+          <!-- 백엔드 팀원이 해결해야 할 부분 대신 해결: 사용자 경험 개선 -->
+          <!-- ======================================== -->
+          {% if "Successfully signed in as" in message %}
+            <!-- 로그인 성공 메시지는 team-setup 페이지에서만 표시 -->
+            {% if request.resolver_match.url_name == 'team-setup' or 'team-setup' in request.path %}
+            <div class="notification-content">
+              <div class="notification-text">
+                <strong>로그인 성공!</strong>
+                <span class="user-email">{{ message|slice:"25:" }} 계정으로 로그인되었습니다</span>
+              </div>
+            </div>
+            {% endif %}
+          {% elif "Successfully signed out" in message %}
+            <div class="notification-content">
+              <div class="notification-text">
+                <strong>로그아웃 완료</strong>
+                <span class="user-email">안전하게 로그아웃되었습니다</span>
+              </div>
+            </div>
+          {% elif "error" in message.tags or "Error" in message %}
+            <div class="notification-content">
+              <div class="notification-text">
+                <strong>오류 발생</strong>
+                <span class="user-email">{{ message }}</span>
+              </div>
+            </div>
+          {% else %}
+            <div class="notification-content">
+              <span class="notification-text">{{ message }}</span>
+            </div>
+          {% endif %}
           <button class="notification-close" type="button" aria-label="닫기">&times;</button>
-      </div>
+        </div>
         {% endfor %}
       {% endif %}
     </div>

--- a/templates/team/create.html
+++ b/templates/team/create.html
@@ -106,11 +106,11 @@ auth-page team-create-page
             <label class="form-label">초대 코드</label>
             <div class="invite-code-container">
               <div class="invite-code-display">
-                <span class="invite-code" id="invite-code-text">------</span>
+                <span class="invite-code" id="form-invite-code-text">------</span>
                 <button
                   type="button"
                   class="copy-btn"
-                  id="copy-code-btn"
+                  id="form-copy-code-btn"
                   title="코드 복사"
                   aria-label="초대 코드 복사"
                 >
@@ -199,7 +199,7 @@ auth-page team-create-page
             <label class="invite-code-label">초대 코드</label>
             <div class="invite-code-container">
               <div class="invite-code-display">
-                <span class="invite-code" id="invite-code-text">------</span>
+                <span class="invite-code" id="success-invite-code-text">------</span>
                 <button
                   type="button"
                   class="copy-btn"
@@ -279,5 +279,9 @@ auth-page team-create-page
 {% endblock %}
 
 {% block extra_js %}
+<script>
+console.log('HTML 템플릿 JavaScript 로드됨');
+console.log('초대 코드 요소 확인:', document.getElementById('form-invite-code-text'));
+</script>
 <script src="{% static 'js/pages/team-create.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## **PR: 팀 생성 초대 코드 일관성 및 로그인 메시지 개선**

### **✨ 주요 개선 사항**

#### **1. 팀 생성 초대 코드 일관성 보장**
- 프론트엔드에서 생성한 코드를 백엔드까지 일관되게 전달
- 팀 생성 → 성공 화면 → 대시보드까지 동일한 초대 코드 유지

#### **2. 로그인 완료 메시지 한국어화 및 디자인 개선**
- "Successfully signed in as" → "로그인 성공! [계정]으로 로그인되었습니다"
- 사진과 동일한 초록색 테마 적용, 엑스버튼 제거

#### **3. 팀 생성 500 에러 해결**
- `invite_code` 변수 미정의로 인한 서버 에러 수정
- 백엔드에서 프론트엔드 초대 코드를 올바르게 수신

---

### **🔧 핵심 변경 사항**

#### **백엔드 (`teams/views.py`)**
```python
# MGP: 프론트엔드에서 전달받은 초대 코드 사용
invite_code = request.data.get('invite_code', '')
```

#### **프론트엔드 (`team-create.js`)**
```javascript
// 페이지 로드 시 초대 코드 미리 생성
generateInviteCode();
```

#### **CSS (`components.css`)**
```css
/* 성공 알림 스타일 - 심플하고 간결한 디자인 */
.notification-success {
  background: #5cb85c;
  border-radius: 8px;
}
```

---

기타 전달사항: ACCOUNT_SIGNUP_REDIRECT_URL = None  이거를 아래처럼 바꿔야 나는 로그인이 돼서 바꿨는데, 해보니까 바꿔도 로그인했던 사용자의 경우 대시보드 가는 로직이나 팀 참여하는거 다 똑같이 작동해서 일단냅뒀는데 혹시 문제 있음 바꿔줘!
ACCOUNT_SIGNUP_REDIRECT_URL = '/profile-setup/' 

그리고 AI의 경우 나는 아직도 아스키 코드 문제 떠서 확실히 작동하는지 테스트를 못해보긴했어 ㅠㅠ 혹시 문제 있으면 알려줘 
